### PR TITLE
Improve event re-delivery.

### DIFF
--- a/fragtale-dbp/src/mb/consumers/delivery_intent_template.rs
+++ b/fragtale-dbp/src/mb/consumers/delivery_intent_template.rs
@@ -18,7 +18,6 @@
 //! Meta-data about an event used during delivery.
 
 use crate::mb::UniqueTime;
-//use crate::mb::event_descriptor::DescriptorVersion;
 
 /// Meta-data about an event used during delivery.
 #[derive(Clone)]


### PR DESCRIPTION
* Avoid advancing the done pointer when there are no delivery intents (yet).
* Don't purge the delivery cache of older entries
* Ensure that code for populating delivery cache has run at least once when the next event is requested.